### PR TITLE
Initial HTTP log implementation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,6 +65,10 @@
         <activity
             android:name=".activities.ConnectionsActivity" />
         <activity
+            android:name=".activities.HttpLogActivity" />
+        <activity
+            android:name=".activities.HttpDetailsActivity" />
+        <activity
             android:name=".activities.AppsActivity"
             android:launchMode="singleTop"
             android:parentActivityName=".activities.MainActivity" />

--- a/app/src/main/java/com/emanuelef/remote_capture/CaptureService.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/CaptureService.java
@@ -132,6 +132,7 @@ public class CaptureService extends VpnService implements Runnable {
     private int[] mAppFilterUids;
     private PcapDumper mDumper;
     private ConnectionsRegister conn_reg;
+    private HttpLog mHttpLog;
     private Uri mPcapUri;
     private String mPcapFname;
     private NotificationCompat.Builder mStatusBuilder;
@@ -327,6 +328,7 @@ public class CaptureService extends VpnService implements Runnable {
         last_connections = 0;
         mLowMemory = false;
         conn_reg = new ConnectionsRegister(this, CONNECTIONS_LOG_SIZE);
+        mHttpLog = new HttpLog();
         mDumper = null;
         mDumpQueue = null;
         mPendingUpdates.clear();
@@ -1032,6 +1034,10 @@ public class CaptureService extends VpnService implements Runnable {
 
     public static @Nullable ConnectionsRegister getConnsRegister() {
         return((INSTANCE != null) ? INSTANCE.conn_reg : null);
+    }
+
+    public static @Nullable HttpLog getHttpLog() {
+        return((INSTANCE != null) ? INSTANCE.mHttpLog : null);
     }
 
     public static @NonNull ConnectionsRegister requireConnsRegister() {

--- a/app/src/main/java/com/emanuelef/remote_capture/HTTPReassembly.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/HTTPReassembly.java
@@ -39,21 +39,33 @@ public class HTTPReassembly {
     private boolean mReadingHeaders;
     private boolean mChunkedEncoding;
     private ContentEncoding mContentEncoding;
-    private String mContentType;
-    private String mPath;
     private int mContentLength;
     private int mHeadersSize;
+    private int mBodySize;
     private final ArrayList<PayloadChunk> mHeaders = new ArrayList<>();
     private final ArrayList<PayloadChunk> mBody = new ArrayList<>();
     private final ReassemblyListener mListener;
+    private final boolean mDumpPayload;
     private boolean mReassembleChunks;
     private boolean mInvalidHttp;
-    private boolean mIsTx;
+    private PayloadChunk mFirstChunk;
 
-    public HTTPReassembly(boolean reassembleChunks, ReassemblyListener listener) {
+    public static final boolean TODO_ENABLED = true;
+
+    /**
+     * @param reassembleChunks if false, all the chunks will be considered as RAW chunks
+     * @param listener a listener for the reassembly
+     * @param dumpPayload if false, PayloadChunk notified via onChunkReassembled will have no payload
+     */
+    public HTTPReassembly(boolean reassembleChunks, ReassemblyListener listener, boolean dumpPayload) {
         mListener = listener;
         mReassembleChunks = reassembleChunks;
+        mDumpPayload = dumpPayload;
         reset();
+    }
+
+    public HTTPReassembly(boolean reassembleChunks, ReassemblyListener listener) {
+        this(reassembleChunks, listener, true);
     }
 
     private enum ContentEncoding {
@@ -63,13 +75,16 @@ public class HTTPReassembly {
         BROTLI,
     }
 
+    private boolean isTx() {
+        return (mFirstChunk != null) && mFirstChunk.is_sent;
+    }
+
     private void reset() {
         mReadingHeaders = true;
         mContentEncoding = ContentEncoding.UNKNOWN;
         mChunkedEncoding = false;
         mContentLength = -1;
-        mContentType = null;
-        mPath = null;
+        mFirstChunk = null;
         mHeadersSize = 0;
         mHeaders.clear();
         mBody.clear();
@@ -84,7 +99,7 @@ public class HTTPReassembly {
     }
 
     private void log_d(String msg) {
-        Log.d(TAG + "(" + (mIsTx ? "TX" : "RX") + ")", msg);
+        Log.d(TAG + "(" + (isTx() ? "TX" : "RX") + ")", msg);
     }
 
     /* The request/response tab shows reassembled HTTP chunks.
@@ -96,7 +111,9 @@ public class HTTPReassembly {
         int body_start = 0;
         byte[] payload = chunk.payload;
         boolean chunked_complete = false;
-        mIsTx = chunk.is_sent;
+
+        if (mFirstChunk == null)
+            mFirstChunk = chunk.withPayload(null);
 
         if(mReadingHeaders) {
             // Reading the HTTP headers
@@ -109,19 +126,49 @@ public class HTTPReassembly {
                 String line = reader.readLine();
 
                 if (is_first_line && (line != null)) {
-                    if (line.startsWith("GET ") || line.startsWith("POST ")
-                            || line.startsWith("HEAD ") || line.startsWith("PUT ")) {
+                    if (chunk.is_sent && (
+                            line.startsWith("GET ") || line.startsWith("POST ") ||
+                            line.startsWith("HEAD ") || line.startsWith("PUT "))
+                    ) {
                         int first_space = line.indexOf(' ');
                         int second_space = line.indexOf(' ', first_space + 1);
 
                         if ((first_space > 0) && (second_space > 0)) {
-                            mPath = line.substring(first_space + 1, second_space);
+                            mFirstChunk.httpMethod = line.substring(0, first_space).toUpperCase();
+                            String path = line.substring(first_space + 1, second_space);
 
-                            int query_start = mPath.indexOf('?');
-                            if (query_start >= 0)
-                                mPath = mPath.substring(0, query_start);
+                            if (!path.startsWith("/")) {
+                                // it may include the protocol and host
+                                int proto_sep = path.indexOf("://");
 
-                            log_d("Path: " + mPath);
+                                if (proto_sep > 0)
+                                    path = path.substring(proto_sep + 3);
+
+                                int slash = path.indexOf('/');
+                                if (slash > 0) {
+                                    mFirstChunk.httpHost = path.substring(0, slash);
+                                    path = path.substring(slash);
+                                }
+                            }
+
+                            int query_start = path.indexOf('?');
+                            if (query_start >= 0) {
+                                path = path.substring(0, query_start);
+                                mFirstChunk.httpQuery = path.substring(query_start);
+                            }
+
+                            log_d("Path: " + path);
+                            mFirstChunk.httpPath = path;
+                        }
+                    } else if (!chunk.is_sent && line.startsWith("HTTP/")) {
+                        int first_space = line.indexOf(' ');
+                        int second_space = line.indexOf(' ', first_space + 1);
+
+                        if ((first_space > 0) && (second_space > 0)) {
+                            try {
+                                mFirstChunk.httpResponseCode = Integer.parseInt(line.substring(first_space + 1, second_space));
+                                mFirstChunk.httpResponseStatus = line.substring(second_space + 1);
+                            } catch (NumberFormatException ignored) {}
                         }
                     }
                 }
@@ -149,9 +196,9 @@ public class HTTPReassembly {
                         }
                     } else if(line.startsWith("content-type: ")) {
                         int endIdx = line.indexOf(";");
-                        mContentType = line.substring(14, (endIdx > 0) ? endIdx : line.length());
+                        mFirstChunk.httpContentType = line.substring(14, (endIdx > 0) ? endIdx : line.length());
 
-                        log_d("Content-Type: " + mContentType);
+                        log_d("Content-Type: " + mFirstChunk.httpContentType);
                     } else if(line.startsWith("content-length: ")) {
                         try {
                             mContentLength = Integer.parseInt(line.substring(16));
@@ -163,6 +210,9 @@ public class HTTPReassembly {
                     } else if(line.equals("transfer-encoding: chunked")) {
                         log_d("Detected chunked encoding");
                         mChunkedEncoding = true;
+                    } else if(line.startsWith("host: ")) {
+                        log_d("Detected HTTP host");
+                        mFirstChunk.httpHost = line.substring(6);
                     }
 
                     line = reader.readLine();
@@ -172,7 +222,9 @@ public class HTTPReassembly {
             if(headers_end > 0) {
                 mReadingHeaders = false;
                 body_start = headers_end;
-                mHeaders.add(chunk.subchunk(0, body_start));
+
+                if (mDumpPayload)
+                    mHeaders.add(chunk.subchunk(0, body_start));
             } else {
                 if(mHeadersSize > MAX_HEADERS_SIZE) {
                     log_d("Assuming not HTTP");
@@ -184,7 +236,8 @@ public class HTTPReassembly {
                 }
 
                 // Headers span all the packet
-                mHeaders.add(chunk);
+                if (mDumpPayload)
+                    mHeaders.add(chunk);
                 body_start = payload.length;
             }
         }
@@ -241,10 +294,14 @@ public class HTTPReassembly {
                     }
                 }
 
-                if((body_start == 0) && (body_size == chunk.payload.length))
-                    mBody.add(chunk);
-                else
-                    mBody.add(chunk.subchunk(body_start, body_size));
+                if (mDumpPayload) {
+                    if ((body_start == 0) && (body_size == chunk.payload.length))
+                        mBody.add(chunk);
+                    else
+                        mBody.add(chunk.subchunk(body_start, body_size));
+                }
+
+                mBodySize += body_size;
             }
 
             if(chunked_complete || !mReassembleChunks)
@@ -252,33 +309,45 @@ public class HTTPReassembly {
 
             if(((mContentLength <= 0) || !mReassembleChunks)
                     && !mChunkedEncoding) {
-                // Reassemble the chunks (NOTE: gzip is applied only after all the chunks are collected)
-                PayloadChunk headers = reassembleChunks(mHeaders);
-                PayloadChunk body = mBody.size() > 0 ? reassembleChunks(mBody) : null;
-
-                //log_d("mContentLength=" + mContentLength + ", mReassembleChunks=" + mReassembleChunks + ", mChunkedEncoding=" + mChunkedEncoding);
-
-                // Decode body
-                if((body != null) && (mContentEncoding != ContentEncoding.UNKNOWN))
-                    decodeBody(body);
-
                 PayloadChunk to_add;
 
-                if(body != null) {
-                    // Reassemble headers and body into a single chunk
-                    byte[] reassembly = new byte[headers.payload.length + body.payload.length];
-                    System.arraycopy(headers.payload, 0, reassembly, 0, headers.payload.length);
-                    System.arraycopy(body.payload, 0, reassembly, headers.payload.length, body.payload.length);
+                if (mDumpPayload) {
+                    // Reassemble the chunks (NOTE: gzip is applied only after all the chunks are collected)
+                    PayloadChunk headers = reassembleChunks(mHeaders);
+                    PayloadChunk body = mBody.size() > 0 ? reassembleChunks(mBody) : null;
 
-                    to_add = body.withPayload(reassembly);
-                } else
-                    to_add = headers;
+                    //log_d("mContentLength=" + mContentLength + ", mReassembleChunks=" + mReassembleChunks + ", mChunkedEncoding=" + mChunkedEncoding);
 
-                if(mInvalidHttp)
+                    // Decode body
+                    if ((body != null) && (mContentEncoding != ContentEncoding.UNKNOWN))
+                        decodeBody(body);
+
+                    if (body != null) {
+                        // Reassemble headers and body into a single chunk
+                        byte[] reassembly = new byte[headers.payload.length + body.payload.length];
+                        System.arraycopy(headers.payload, 0, reassembly, 0, headers.payload.length);
+                        System.arraycopy(body.payload, 0, reassembly, headers.payload.length, body.payload.length);
+
+                        to_add = body.withPayload(reassembly);
+                    } else
+                        to_add = headers;
+                } else {
+                    to_add = mFirstChunk;
+                }
+
+                if (mInvalidHttp)
                     to_add.type = PayloadChunk.ChunkType.RAW;
+                else {
+                    to_add.httpContentType = mFirstChunk.httpContentType;
+                    to_add.httpResponseCode = mFirstChunk.httpResponseCode;
+                    to_add.httpResponseStatus = mFirstChunk.httpResponseStatus;
+                    to_add.httpMethod = mFirstChunk.httpMethod;
+                    to_add.httpHost = mFirstChunk.httpHost;
+                    to_add.httpPath = mFirstChunk.httpPath;
+                    to_add.httpQuery = mFirstChunk.httpQuery;
+                    to_add.httpBodyLength = mBodySize;
+                }
 
-                to_add.contentType = mContentType;
-                to_add.path = mPath;
                 mListener.onChunkReassembled(to_add);
                 reset(); // mReadingHeaders = true
             }

--- a/app/src/main/java/com/emanuelef/remote_capture/HttpLog.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/HttpLog.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of PCAPdroid.
+ *
+ * PCAPdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PCAPdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PCAPdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2020-24 - Emanuele Faranda
+ */
+
+package com.emanuelef.remote_capture;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.emanuelef.remote_capture.model.ConnectionDescriptor;
+
+import java.util.ArrayList;
+
+public class HttpLog {
+    private final ArrayList<HttpRequest> mHttpRequests = new ArrayList<>();
+    private Listener mListener;
+
+    public static class HttpRequest {
+        public final ConnectionDescriptor conn;
+        public final int firstChunkPos;
+        public String method = "";
+        public String host = "";
+        public String path = "";
+        public String query = "";
+        public HttpReply reply;
+        public int bodyLength;
+        public long timestamp;
+        private int idx = -1;
+
+        public HttpRequest(ConnectionDescriptor conn, int firstChunkPos) {
+            this.conn = conn;
+            this.firstChunkPos = firstChunkPos;
+        }
+
+        public int getPosition() {
+            return idx;
+        }
+
+        public String getProtoAndHost() {
+            String l7proto = conn.l7proto.toLowerCase();
+            String proto = l7proto.startsWith("http") ? (l7proto + "://") : "";
+
+            return proto + host;
+        }
+
+        public String getUrl() {
+            return String.format("%s%s%s", getProtoAndHost(), path, query);
+        }
+
+        @Override
+        @NonNull
+        public String toString() {
+            return "HTTP request: " + method + " " + getUrl();
+        }
+    }
+
+    public static class HttpReply {
+        public final HttpRequest request;
+        public final int firstChunkPos;
+        public String contentType;
+        public String responseStatus;
+        public int responseCode;
+        public int bodyLength;
+
+        public HttpReply(@NonNull HttpRequest in_reply_to, int firstChunkPos) {
+            request = in_reply_to;
+            this.firstChunkPos = firstChunkPos;
+        }
+
+        @Override
+        @NonNull
+        public String toString() {
+            return "HTTP reply: " + responseCode + " " +
+                    responseStatus + " - " + contentType + " - " +
+                    bodyLength + " B";
+        }
+    }
+
+    public interface Listener {
+        void onHttpRequestAdded(int pos);
+        void onHttpRequestUpdated(int pos);
+        void onHttpRequestsClear();
+    }
+
+    public synchronized void setListener(Listener listener) {
+        mListener = listener;
+    }
+
+    public synchronized void addHttpRequest(HttpRequest req) {
+        req.idx = mHttpRequests.size();
+        mHttpRequests.add(req);
+
+        if (mListener != null)
+            mListener.onHttpRequestAdded(req.idx);
+    }
+
+    public synchronized void addHttpReply(HttpReply reply) {
+        assert (reply.request.reply == reply);
+
+        if (mListener != null)
+            // info from the HTTP reply is now available
+            mListener.onHttpRequestUpdated(reply.request.idx);
+    }
+
+    public synchronized void clear() {
+        mHttpRequests.clear();
+
+        if (mListener != null)
+            mListener.onHttpRequestsClear();
+    }
+
+    public synchronized @Nullable HttpRequest getRequest(int pos) {
+        if ((pos < 0) || (pos >= mHttpRequests.size()))
+            return null;
+        return mHttpRequests.get(pos);
+    }
+
+    public synchronized int size() {
+        return mHttpRequests.size();
+    }
+}

--- a/app/src/main/java/com/emanuelef/remote_capture/activities/ConnectionDetailsActivity.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/ConnectionDetailsActivity.java
@@ -19,9 +19,6 @@
 
 package com.emanuelef.remote_capture.activities;
 
-import androidx.activity.result.ActivityResult;
-import androidx.activity.result.ActivityResultLauncher;
-import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -29,7 +26,6 @@ import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 
 import android.annotation.SuppressLint;
-import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -40,8 +36,6 @@ import com.emanuelef.remote_capture.CaptureService;
 import com.emanuelef.remote_capture.ConnectionsRegister;
 import com.emanuelef.remote_capture.Log;
 import com.emanuelef.remote_capture.R;
-import com.emanuelef.remote_capture.Utils;
-import com.emanuelef.remote_capture.adapters.PayloadAdapter;
 import com.emanuelef.remote_capture.fragments.ConnectionOverview;
 import com.emanuelef.remote_capture.fragments.ConnectionPayload;
 import com.emanuelef.remote_capture.interfaces.ConnectionsListener;
@@ -50,12 +44,9 @@ import com.emanuelef.remote_capture.model.PayloadChunk;
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 
-public class ConnectionDetailsActivity extends BaseActivity implements ConnectionsListener, PayloadAdapter.ExportPayloadHandler {
+public class ConnectionDetailsActivity extends PayloadExportActivity implements ConnectionsListener {
     private static final String TAG = "ConnectionDetails";
     public static final String CONN_ID_KEY = "conn_id";
     private static final int MAX_CHUNKS_TO_CHECK = 10;
@@ -69,17 +60,12 @@ public class ConnectionDetailsActivity extends BaseActivity implements Connectio
     private boolean mHasPayload;
     private boolean mHasHttpTab;
     private boolean mHasWsTab;
-    private String mStringPayloadToExport;
-    private byte[] mRawPayloadToExport;
     private final ArrayList<ConnUpdateListener> mListeners = new ArrayList<>();
 
     private static final int POS_OVERVIEW = 0;
     private static final int POS_WEBSOCKET = 1;
     private static final int POS_HTTP = 2;
     private static final int POS_RAW_PAYLOAD = 3;
-
-    private final ActivityResultLauncher<Intent> payloadExportLauncher =
-            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), this::payloadExportResult);
 
     public interface ConnUpdateListener {
         void connectionUpdated();
@@ -342,84 +328,5 @@ public class ConnectionDetailsActivity extends BaseActivity implements Connectio
         }
 
         return super.onKeyDown(keyCode, event);
-    }
-
-    @Override
-    public void exportPayload(String payload) {
-        mStringPayloadToExport = payload;
-        mRawPayloadToExport = null;
-
-        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType("text/plain");
-        intent.putExtra(Intent.EXTRA_TITLE, Utils.getUniqueFileName(this, "txt"));
-
-        Utils.launchFileDialog(this, intent, payloadExportLauncher);
-    }
-
-    @Override
-    public void exportPayload(byte[] payload, String contentType, String fname) {
-        mStringPayloadToExport = null;
-        mRawPayloadToExport = payload;
-
-        if (fname.isEmpty()) {
-            String ext;
-
-            switch (contentType) {
-                case "text/html":
-                    ext = "html";
-                    break;
-                case "application/octet-stream":
-                    ext = "bin";
-                    break;
-                case "application/json":
-                    ext = "json";
-                    break;
-                default:
-                    ext = "txt";
-            }
-
-            fname = Utils.getUniqueFileName(this, ext);
-        }
-
-        /* This is an unmapped mime type, which allows the user to specify the file,
-         * extension instead of Android forcing it, see
-         * https://android.googlesource.com/platform/external/mime-support/+/fa3f892f28db393b1411f046877ee48179f6a4cf/mime.types */
-        final String generic_mime = "application/http";
-
-        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType(generic_mime);
-        intent.putExtra(Intent.EXTRA_TITLE, fname);
-
-        Utils.launchFileDialog(this, intent, payloadExportLauncher);
-    }
-
-    private void payloadExportResult(final ActivityResult result) {
-        Log.d(TAG, "payloadExportResult");
-
-        if ((mRawPayloadToExport == null) && (mStringPayloadToExport == null))
-            return;
-
-        if((result.getResultCode() == RESULT_OK) && (result.getData() != null) && (result.getData().getData() != null)) {
-            try(OutputStream out = getContentResolver().openOutputStream(result.getData().getData(), "rwt")) {
-                if (out != null) {
-                    if (mStringPayloadToExport != null) {
-                        try (OutputStreamWriter writer = new OutputStreamWriter(out)) {
-                            writer.write(mStringPayloadToExport);
-                        }
-                    } else
-                        out.write(mRawPayloadToExport);
-                    Utils.showToast(this, R.string.save_ok);
-                } else
-                    Utils.showToastLong(this, R.string.export_failed);
-            } catch (IOException e) {
-                e.printStackTrace();
-                Utils.showToastLong(this, R.string.export_failed);
-            }
-        }
-
-        mRawPayloadToExport = null;
-        mStringPayloadToExport = null;
     }
 }

--- a/app/src/main/java/com/emanuelef/remote_capture/activities/HttpDetailsActivity.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/HttpDetailsActivity.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of PCAPdroid.
+ *
+ * PCAPdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PCAPdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PCAPdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2020-24 - Emanuele Faranda
+ */
+
+package com.emanuelef.remote_capture.activities;
+
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
+import androidx.viewpager2.widget.ViewPager2;
+
+import com.emanuelef.remote_capture.CaptureService;
+import com.emanuelef.remote_capture.HttpLog;
+import com.emanuelef.remote_capture.Log;
+import com.emanuelef.remote_capture.R;
+import com.emanuelef.remote_capture.fragments.HttpPayloadFragment;
+import com.google.android.material.tabs.TabLayoutMediator;
+
+public class HttpDetailsActivity extends PayloadExportActivity {
+    private static final String TAG = "HttpRequestDetailsActivity";
+    public static final String HTTP_REQ_POS_KEY = "req_pos";
+    private HttpLog.HttpRequest mHttpReq;
+    private ViewPager2 mPager;
+    private StateAdapter mPagerAdapter;
+
+    private static final int POS_REQUEST = 0;
+    private static final int POS_REPLY = 1;
+    private static final int POS_COUNT = 2;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setTitle(R.string.http_details);
+        displayBackAction();
+        setContentView(R.layout.tabs_activity_fixed);
+
+        int req_pos = getIntent().getIntExtra(HTTP_REQ_POS_KEY, -1);
+        if(req_pos != -1) {
+            HttpLog httpLog = CaptureService.getHttpLog();
+            if(httpLog != null)
+                mHttpReq = httpLog.getRequest(req_pos);
+        }
+
+        if(mHttpReq == null) {
+            Log.w(TAG, "HTTP request with position " + req_pos + " not found");
+            finish();
+            return;
+        }
+
+        mPager = findViewById(R.id.pager);
+        setupTabs();
+    }
+
+    private void setupTabs() {
+        mPagerAdapter = new StateAdapter(this);
+        mPager.setAdapter(mPagerAdapter);
+
+        new TabLayoutMediator(findViewById(R.id.tablayout), mPager, (tab, position) ->
+                tab.setText(getString(mPagerAdapter.getPageTitle(position)))
+        ).attach();
+    }
+
+    private class StateAdapter extends FragmentStateAdapter {
+        StateAdapter(final FragmentActivity fa) { super(fa); }
+
+        @NonNull
+        @Override
+        public Fragment createFragment(int pos) {
+            //Log.d(TAG, "createFragment");
+            int req_pos = mHttpReq.getPosition();
+
+            switch (pos) {
+                case POS_REPLY:
+                    return HttpPayloadFragment.newInstance(req_pos, true);
+                case POS_REQUEST:
+                default:
+                    return HttpPayloadFragment.newInstance(req_pos, false);
+            }
+        }
+
+        @Override
+        public int getItemCount() {  return POS_COUNT;  }
+
+        public int getPageTitle(final int pos) {
+            switch (pos) {
+                case POS_REPLY:
+                    return R.string.response;
+                default:
+                    return R.string.request;
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/emanuelef/remote_capture/activities/HttpLogActivity.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/HttpLogActivity.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with PCAPdroid.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright 2020-21 - Emanuele Faranda
+ * Copyright 2020-24 - Emanuele Faranda
  */
 
 package com.emanuelef.remote_capture.activities;
@@ -22,18 +22,18 @@ package com.emanuelef.remote_capture.activities;
 import android.os.Bundle;
 
 import com.emanuelef.remote_capture.R;
-import com.emanuelef.remote_capture.fragments.ConnectionsFragment;
+import com.emanuelef.remote_capture.fragments.HttpLogFragment;
 
-public class ConnectionsActivity extends BaseActivity {
+public class HttpLogActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setTitle(R.string.connections_view);
-        displayBackAction(); // Use explicit back to restore the AppDetailsActivity state
+        setTitle(R.string.http_log);
+        displayBackAction();
         setContentView(R.layout.fragment_activity);
 
         getSupportFragmentManager().beginTransaction()
-                .replace(R.id.fragment, new ConnectionsFragment())
+                .replace(R.id.fragment, new HttpLogFragment())
                 .commit();
     }
 }

--- a/app/src/main/java/com/emanuelef/remote_capture/activities/MainActivity.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/MainActivity.java
@@ -514,6 +514,9 @@ public class MainActivity extends BaseActivity implements NavigationView.OnNavig
             Intent intent = new Intent(MainActivity.this, EditListActivity.class);
             intent.putExtra(EditListActivity.LIST_TYPE_EXTRA, ListInfo.Type.DECRYPTION_LIST);
             startActivity(intent);
+        } else if(id == R.id.http_log) {
+            Intent intent = new Intent(MainActivity.this, HttpLogActivity.class);
+            startActivity(intent);
         } else if(id == R.id.firewall) {
             Intent intent = new Intent(MainActivity.this, FirewallActivity.class);
             startActivity(intent);

--- a/app/src/main/java/com/emanuelef/remote_capture/activities/PayloadExportActivity.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/PayloadExportActivity.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of PCAPdroid.
+ *
+ * PCAPdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PCAPdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PCAPdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2020-24 - Emanuele Faranda
+ */
+
+package com.emanuelef.remote_capture.activities;
+
+import android.content.Intent;
+
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+
+import com.emanuelef.remote_capture.R;
+import com.emanuelef.remote_capture.Utils;
+import com.emanuelef.remote_capture.adapters.PayloadAdapter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+
+public class PayloadExportActivity extends BaseActivity implements PayloadAdapter.ExportPayloadHandler {
+    private String mStringPayloadToExport;
+    private byte[] mRawPayloadToExport;
+
+    private final ActivityResultLauncher<Intent> payloadExportLauncher =
+            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), this::payloadExportResult);
+
+    @Override
+    public void exportPayload(String payload) {
+        mStringPayloadToExport = payload;
+        mRawPayloadToExport = null;
+
+        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_TITLE, Utils.getUniqueFileName(this, "txt"));
+
+        Utils.launchFileDialog(this, intent, payloadExportLauncher);
+    }
+
+    @Override
+    public void exportPayload(byte[] payload, String contentType, String fname) {
+        mStringPayloadToExport = null;
+        mRawPayloadToExport = payload;
+
+        if (fname.isEmpty()) {
+            String ext;
+
+            switch (contentType) {
+                case "text/html":
+                    ext = "html";
+                    break;
+                case "application/octet-stream":
+                    ext = "bin";
+                    break;
+                case "application/json":
+                    ext = "json";
+                    break;
+                default:
+                    ext = "txt";
+            }
+
+            fname = Utils.getUniqueFileName(this, ext);
+        }
+
+        /* This is an unmapped mime type, which allows the user to specify the file,
+         * extension instead of Android forcing it, see
+         * https://android.googlesource.com/platform/external/mime-support/+/fa3f892f28db393b1411f046877ee48179f6a4cf/mime.types */
+        final String generic_mime = "application/http";
+
+        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType(generic_mime);
+        intent.putExtra(Intent.EXTRA_TITLE, fname);
+
+        Utils.launchFileDialog(this, intent, payloadExportLauncher);
+    }
+
+    private void payloadExportResult(final ActivityResult result) {
+        if ((mRawPayloadToExport == null) && (mStringPayloadToExport == null))
+            return;
+
+        if((result.getResultCode() == RESULT_OK) && (result.getData() != null) && (result.getData().getData() != null)) {
+            try(OutputStream out = getContentResolver().openOutputStream(result.getData().getData(), "rwt")) {
+                if (out != null) {
+                    if (mStringPayloadToExport != null) {
+                        try (OutputStreamWriter writer = new OutputStreamWriter(out)) {
+                            writer.write(mStringPayloadToExport);
+                        }
+                    } else
+                        out.write(mRawPayloadToExport);
+                    Utils.showToast(this, R.string.save_ok);
+                } else
+                    Utils.showToastLong(this, R.string.export_failed);
+            } catch (IOException e) {
+                e.printStackTrace();
+                Utils.showToastLong(this, R.string.export_failed);
+            }
+        }
+
+        mRawPayloadToExport = null;
+        mStringPayloadToExport = null;
+    }
+}

--- a/app/src/main/java/com/emanuelef/remote_capture/adapters/ConnectionsAdapter.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/adapters/ConnectionsAdapter.java
@@ -229,7 +229,7 @@ public class ConnectionsAdapter extends RecyclerView.Adapter<ConnectionsAdapter.
     public long getItemId(int pos) {
         ConnectionDescriptor conn = getItem(pos);
 
-        return ((conn != null) ? conn.incr_id : Utils.UID_UNKNOWN);
+        return ((conn != null) ? conn.incr_id : -1);
     }
 
     private boolean matches(ConnectionDescriptor conn) {

--- a/app/src/main/java/com/emanuelef/remote_capture/adapters/HttpLogAdapter.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/adapters/HttpLogAdapter.java
@@ -1,0 +1,288 @@
+/*
+ * This file is part of PCAPdroid.
+ *
+ * PCAPdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PCAPdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PCAPdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2020-24 - Emanuele Faranda
+ */
+
+package com.emanuelef.remote_capture.adapters;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.util.SparseIntArray;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.emanuelef.remote_capture.AppsResolver;
+import com.emanuelef.remote_capture.CaptureService;
+import com.emanuelef.remote_capture.HttpLog;
+import com.emanuelef.remote_capture.HttpLog.HttpRequest;
+import com.emanuelef.remote_capture.Log;
+import com.emanuelef.remote_capture.R;
+import com.emanuelef.remote_capture.Utils;
+import com.emanuelef.remote_capture.model.AppDescriptor;
+import com.emanuelef.remote_capture.model.ConnectionDescriptor;
+
+import java.util.ArrayList;
+
+public class HttpLogAdapter extends RecyclerView.Adapter<HttpLogAdapter.ViewHolder> implements HttpLog.Listener {
+    private static final String TAG = "HttpLogAdapter";
+    private final LayoutInflater mLayoutInflater;
+    private final Drawable mUnknownIcon;
+    private View.OnClickListener mListener;
+    private final AppsResolver mAppsResolver;
+    private final Context mContext;
+    private HttpRequest mSelectedItem;
+
+    // maps a positions from HttpLog to mFilteredReqs.
+    private final SparseIntArray mIdToFilteredPos;
+
+    private ArrayList<HttpRequest> mFilteredReqs;
+    private String mSearch;
+
+    public static class ViewHolder extends RecyclerView.ViewHolder {
+        ImageView icon;
+        TextView appName;
+        TextView methodAndPath;
+        TextView protoAndHost;
+        TextView contentType;
+        TextView reqTime;
+        TextView httpStatus;
+        TextView payloadSize;
+
+        ViewHolder(View itemView) {
+            super(itemView);
+
+            icon = itemView.findViewById(R.id.icon);
+            appName = itemView.findViewById(R.id.app_name);
+            methodAndPath = itemView.findViewById(R.id.method_and_path);
+            protoAndHost = itemView.findViewById(R.id.proto_and_host);
+            contentType = itemView.findViewById(R.id.content_type);
+            reqTime = itemView.findViewById(R.id.req_time);
+            httpStatus = itemView.findViewById(R.id.http_status);
+            payloadSize = itemView.findViewById(R.id.payload_size);
+        }
+
+        public void bindItem(HttpRequest req, Context ctx, AppsResolver apps, Drawable unknownIcon) {
+            AppDescriptor app = apps.getAppByUid(req.conn.uid, 0);
+
+            Drawable appIcon = ((app != null) && (app.getIcon() != null)) ? app.getIcon() : unknownIcon;
+            icon.setImageDrawable(appIcon);
+
+            String info_txt = (app != null) ? app.getName() : Integer.toString(req.conn.uid);
+            appName.setText(info_txt);
+
+            methodAndPath.setText(String.format("%s %s", req.method, req.path));
+            protoAndHost.setText(req.getProtoAndHost());
+            contentType.setText((req.reply != null) ? req.reply.contentType : "");
+            reqTime.setText(Utils.formatEpochShort(ctx, req.timestamp / 1000));
+            httpStatus.setText((req.reply != null) ?
+                    String.format(Utils.getPrimaryLocale(ctx), "%d %s", req.reply.responseCode, req.reply.responseStatus) : "—");
+
+            int tot_length = (req.reply != null) ? (req.bodyLength + req.reply.bodyLength) : req.bodyLength;
+            payloadSize.setText(Utils.formatBytes(tot_length));
+
+            if (req.reply != null) {
+                int code = req.reply.responseCode;
+                int color;
+
+                if((code >= 200) && (code <= 299))
+                    color = R.color.statusOpen;
+                else if((code >= 300) && (code <= 399))
+                    color = R.color.lightGray;
+                else if((code >= 400) && (code <= 599))
+                    color = R.color.statusError;
+                else
+                    color = R.color.colorTabText;
+
+                httpStatus.setTextColor(ContextCompat.getColor(ctx, color));
+            }
+        }
+    }
+
+    public HttpLogAdapter(Context context, AppsResolver resolver) {
+        mContext = context;
+        mAppsResolver = resolver;
+        mLayoutInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        mUnknownIcon = ContextCompat.getDrawable(context, R.drawable.ic_image);
+        mIdToFilteredPos = new SparseIntArray();
+        mListener = null;
+        mFilteredReqs = null;
+        mSearch = null;
+        setHasStableIds(true);
+
+        refreshFilteredItems();
+    }
+
+    @Override
+    public int getItemCount() {
+        if (mFilteredReqs != null)
+            return mFilteredReqs.size();
+
+        HttpLog httpLog = CaptureService.getHttpLog();
+        return((httpLog != null) ? httpLog.size() : 0);
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = mLayoutInflater.inflate(R.layout.http_req_item, parent, false);
+
+        if(mListener != null)
+            view.setOnClickListener(mListener);
+
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        HttpRequest item = getItem(position);
+        if(item == null) {
+            Log.w(TAG, "bad position: " + position);
+            return;
+        }
+
+        holder.bindItem(item, mContext, mAppsResolver, mUnknownIcon);
+    }
+
+    @Override
+    public long getItemId(int pos) {
+        HttpRequest item = getItem(pos);
+
+        return ((item != null) ? item.getPosition() : -1);
+    }
+
+    public @Nullable HttpRequest getItem(int pos) {
+        if(mFilteredReqs != null) {
+            if((pos < 0) || (pos >= mFilteredReqs.size())) {
+                Log.w(TAG, "getItem(filtered): bad position: " + pos);
+                return null;
+            }
+            return mFilteredReqs.get(pos);
+        }
+
+        HttpLog httpLog = CaptureService.getHttpLog();
+        if((httpLog == null) || (pos < 0) || (pos >= httpLog.size())) {
+            Log.w(TAG, "getItem: bad position: " + pos);
+            return null;
+        }
+
+        return httpLog.getRequest(pos);
+    }
+
+    @Override
+    public void onHttpRequestAdded(int pos) {
+        Log.d(TAG, "onHttpRequestAdded " + pos);
+        HttpLog httpLog = CaptureService.getHttpLog();
+        if (httpLog == null)
+            return;
+
+        HttpRequest req = httpLog.getRequest(pos);
+        if (req == null)
+            return;
+
+        if (mFilteredReqs != null) {
+            if (matches(req)) {
+                int filtered_pos = mFilteredReqs.size();
+                mIdToFilteredPos.put(pos, filtered_pos);
+                mFilteredReqs.add(req);
+                notifyItemInserted(filtered_pos);
+            }
+        } else
+            notifyItemInserted(pos);
+    }
+
+    @Override
+    public void onHttpRequestUpdated(int pos) {
+        if (mFilteredReqs == null) {
+            if ((pos >= 0) && (pos < getItemCount()))
+                notifyItemChanged(pos);
+        } else {
+            // check if this item is matched
+            int filtered_pos = mIdToFilteredPos.get(pos, -1);
+            if (filtered_pos != -1)
+                notifyItemChanged(filtered_pos);
+        }
+    }
+
+    @Override
+    public void onHttpRequestsClear() {
+        mSelectedItem = null;
+        refreshFilteredItems();
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    public void refreshFilteredItems() {
+        mIdToFilteredPos.clear();
+        mFilteredReqs = null;
+
+        final HttpLog httpLog = CaptureService.getHttpLog();
+        if(httpLog != null) {
+            Log.d(TAG, "refreshFilteredConn (" + httpLog.size() + ") unfiltered");
+
+            if (hasFilter()) {
+                int pos = 0;
+                mFilteredReqs = new ArrayList<>();
+
+                // Synchronize to improve performance of getConn
+                synchronized (httpLog) {
+                    for (int i = 0; i < httpLog.size(); i++) {
+                        HttpRequest req = httpLog.getRequest(i);
+
+                        if ((req != null) && matches(req)) {
+                            mFilteredReqs.add(req);
+                            mIdToFilteredPos.put(i, pos++);
+                        }
+                    }
+                }
+
+                Log.d(TAG, "refreshFilteredItems: " + mFilteredReqs.size() + " items matched");
+            }
+        }
+
+        notifyDataSetChanged();
+    }
+
+    private boolean matches(HttpRequest req) {
+        // TODO
+        return true;
+    }
+
+    public void setSearch(String text) {
+        mSearch = text;
+        refreshFilteredItems();
+    }
+
+    public void setClickListener(View.OnClickListener listener) {
+        mListener = listener;
+    }
+
+    public HttpRequest getSelectedItem() {
+        return mSelectedItem;
+    }
+
+    public boolean hasFilter() {
+        return (mSearch != null);
+    }
+}

--- a/app/src/main/java/com/emanuelef/remote_capture/adapters/PayloadAdapter.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/adapters/PayloadAdapter.java
@@ -34,6 +34,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.emanuelef.remote_capture.CaptureService;
 import com.emanuelef.remote_capture.HTTPReassembly;
+import com.emanuelef.remote_capture.HttpLog;
 import com.emanuelef.remote_capture.Log;
 import com.emanuelef.remote_capture.R;
 import com.emanuelef.remote_capture.Utils;
@@ -69,6 +70,7 @@ public class PayloadAdapter extends RecyclerView.Adapter<PayloadAdapter.PayloadV
     private final HTTPReassembly mHttpReq;
     private final HTTPReassembly mHttpRes;
     private final boolean mSupportsFileDialog;
+    private final PayloadChunk mSingleChunk;
     private boolean mShowAsPrintable;
     private ExportPayloadHandler mExportHandler;
 
@@ -77,22 +79,51 @@ public class PayloadAdapter extends RecyclerView.Adapter<PayloadAdapter.PayloadV
         void exportPayload(byte[] payload, String contentType, String fname);
     }
 
-    public PayloadAdapter(Context context, ConnectionDescriptor conn, ChunkType mode, boolean showAsPrintable) {
+    /* if singleChunk is set, this adapter will only show that chunk */
+    private PayloadAdapter(Context context, ConnectionDescriptor conn, ChunkType mode,
+                          boolean showAsPrintable, PayloadChunk singleChunk) {
         mLayoutInflater = (LayoutInflater)context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         mConn = conn;
         mContext = context;
         mMode = mode;
         mShowAsPrintable = showAsPrintable;
         mSupportsFileDialog = Utils.supportsFileDialog(context);
+        mSingleChunk = singleChunk;
 
-        // Note: in minimal mode, only the first chunk is captured, so don't reassemble them
-        boolean reassemble = (CaptureService.getCurPayloadMode() == Prefs.PayloadMode.FULL);
+        if (mSingleChunk == null) {
+            // Note: in minimal mode, only the first chunk is captured, so don't reassemble them
+            boolean reassemble = (CaptureService.getCurPayloadMode() == Prefs.PayloadMode.FULL);
 
-        // each direction must have its separate reassembly
-        mHttpReq = new HTTPReassembly(reassemble, this);
-        mHttpRes = new HTTPReassembly(reassemble, this);
+            // each direction must have its separate reassembly
+            mHttpReq = new HTTPReassembly(reassemble, this);
+            mHttpRes = new HTTPReassembly(reassemble, this);
 
-        handleChunksAdded(mConn.getNumPayloadChunks());
+            handleChunksAdded(mConn.getNumPayloadChunks());
+        } else {
+            mHttpReq = null;
+            mHttpRes = null;
+
+            mChunks.add(new AdapterChunk(mSingleChunk, 0));
+            notifyItemInserted(0);
+        }
+    }
+
+    public PayloadAdapter(Context context, ConnectionDescriptor conn, ChunkType mode,  boolean showAsPrintable) {
+        this(context, conn, mode, showAsPrintable, null);
+    }
+
+    public PayloadAdapter(Context context, HttpLog.HttpRequest req, boolean show_reply) {
+        this(context, req.conn, ChunkType.HTTP, true, getChunk(req, show_reply));
+    }
+
+    private static PayloadChunk getChunk(HttpLog.HttpRequest req, boolean show_reply) {
+        if (show_reply) {
+            if (req.reply != null)
+                return req.conn.getHttpResponseChunk(req.reply.firstChunkPos);
+        } else
+            return req.conn.getHttpRequestChunk(req.firstChunkPos);
+
+        return null;
     }
 
     public void setExportPayloadHandler(ExportPayloadHandler handler) {
@@ -277,19 +308,19 @@ public class PayloadAdapter extends RecyclerView.Adapter<PayloadAdapter.PayloadV
         if(mMode == ChunkType.HTTP) {
             String payload = chunk.getExpandedText(true);
             int crlf_pos = payload.indexOf("\r\n\r\n");
-            String content_type = ((chunk.mChunk.contentType != null) && (!chunk.mChunk.contentType.isEmpty())) ?
-                    chunk.mChunk.contentType : "text/plain";
+            String content_type = ((chunk.mChunk.httpContentType != null) && (!chunk.mChunk.httpContentType.isEmpty())) ?
+                    chunk.mChunk.httpContentType : "text/plain";
 
             Log.d(TAG, "Export body content type: " + content_type);
 
             String fname = "";
-            if (chunk.mChunk.is_sent && (chunk.mChunk.path != null))
-                fname = chunk.mChunk.path;
+            if (chunk.mChunk.is_sent && (chunk.mChunk.httpPath != null))
+                fname = chunk.mChunk.httpPath;
             else if (payload_pos > 0) {
                 // Try to match the HTTP request, to determine the file name
                 AdapterChunk req_chunk = getItem(payload_pos - 1).adaptChunk;
-                if (req_chunk.mChunk.is_sent && (req_chunk.mChunk.path != null))
-                    fname = req_chunk.mChunk.path;
+                if (req_chunk.mChunk.is_sent && (req_chunk.mChunk.httpPath != null))
+                    fname = req_chunk.mChunk.httpPath;
             }
 
             if (!fname.isEmpty()) {
@@ -407,11 +438,18 @@ public class PayloadAdapter extends RecyclerView.Adapter<PayloadAdapter.PayloadV
             holder.headerLine.setVisibility(View.VISIBLE);
 
             Locale locale = Utils.getPrimaryLocale(mContext);
-            holder.header.setText(String.format(locale,
-                    "#%d [%s] %s — %s", page.adaptChunk.incrId + 1,
-                    getHeaderTag(chunk),
-                    (new SimpleDateFormat("HH:mm:ss.SSS", locale)).format(new Date(chunk.timestamp)),
-                    Utils.formatBytes(chunk.payload.length)));
+            String formattedTstamp = (new SimpleDateFormat("HH:mm:ss.SSS", locale)).format(new Date(chunk.timestamp));
+            String formattedBytes = Utils.formatBytes(chunk.payload.length);
+
+            if (mSingleChunk == null)
+                holder.header.setText(String.format(locale,
+                        "#%d [%s] %s — %s", page.adaptChunk.incrId + 1,
+                        getHeaderTag(chunk),
+                        formattedTstamp, formattedBytes));
+            else
+                holder.header.setText(String.format(locale,
+                        "%s — %s",
+                        formattedTstamp, formattedBytes));
         } else
             holder.headerLine.setVisibility(View.GONE);
 
@@ -542,6 +580,7 @@ public class PayloadAdapter extends RecyclerView.Adapter<PayloadAdapter.PayloadV
         mUnrepliedHttpReq = null;
     }
 
+    @SuppressLint("DefaultLocale")
     @Override
     public void onChunkReassembled(PayloadChunk chunk) {
         AdapterChunk adapterChunk = new AdapterChunk(chunk, mChunks.size());

--- a/app/src/main/java/com/emanuelef/remote_capture/fragments/ConnectionsFragment.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/fragments/ConnectionsFragment.java
@@ -215,13 +215,11 @@ public class ConnectionsFragment extends Fragment implements ConnectionsListener
 
         autoScroll = true;
         showFabDown(false);
-
         mFabDown.setOnClickListener(v -> scrollToBottom());
 
         mRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override
             public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
-            //public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int state) {
                 recheckScroll();
             }
         });

--- a/app/src/main/java/com/emanuelef/remote_capture/fragments/HttpLogFragment.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/fragments/HttpLogFragment.java
@@ -1,0 +1,300 @@
+/*
+ * This file is part of PCAPdroid.
+ *
+ * PCAPdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PCAPdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PCAPdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2020-24 - Emanuele Faranda
+ */
+
+package com.emanuelef.remote_capture.fragments;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.SearchView;
+import androidx.core.view.MenuProvider;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
+import androidx.recyclerview.widget.DividerItemDecoration;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.emanuelef.remote_capture.AppsResolver;
+import com.emanuelef.remote_capture.CaptureService;
+import com.emanuelef.remote_capture.HttpLog;
+import com.emanuelef.remote_capture.R;
+import com.emanuelef.remote_capture.Utils;
+import com.emanuelef.remote_capture.activities.HttpDetailsActivity;
+import com.emanuelef.remote_capture.adapters.HttpLogAdapter;
+import com.emanuelef.remote_capture.views.EmptyRecyclerView;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+public class HttpLogFragment extends Fragment implements HttpLog.Listener, MenuProvider, SearchView.OnQueryTextListener {
+    private static final String TAG = "HttpLogFragment";
+    private TextView mEmptyText;
+    private HttpLogAdapter mAdapter;
+    private EmptyRecyclerView mRecyclerView;
+    private FloatingActionButton mFabDown;
+    private MenuItem mMenuItemSearch;
+    private SearchView mSearchView;
+    private Handler mHandler;
+
+    private String mQueryToApply;
+    private AppsResolver mApps;
+    private boolean autoScroll;
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        refreshEmptyText();
+
+        registerHttpListener();
+        mRecyclerView.setEmptyView(mEmptyText); // after registerConnsListener, when the adapter is populated
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+
+        unregisterHttpListener();
+        mRecyclerView.setEmptyView(null);
+
+        if(mSearchView != null)
+            mQueryToApply = mSearchView.getQuery().toString();
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        if(mSearchView != null)
+            outState.putString("search", mSearchView.getQuery().toString());
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater,
+                             ViewGroup container, Bundle savedInstanceState) {
+        requireActivity().addMenuProvider(this, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
+        return inflater.inflate(R.layout.connections, container, false);
+    }
+
+    private void registerHttpListener() {
+        HttpLog httpLog = CaptureService.getHttpLog();
+
+        if (httpLog != null)
+            httpLog.setListener(this);
+
+        if (mAdapter != null) {
+            mAdapter.onHttpRequestsClear();
+            recheckScroll();
+            scrollToBottom();
+        }
+    }
+
+    private void unregisterHttpListener() {
+        HttpLog httpLog = CaptureService.getHttpLog();
+
+        if (httpLog != null)
+            httpLog.setListener(null);
+
+        if (mAdapter != null) {
+            mAdapter.onHttpRequestsClear();
+            recheckScroll();
+            scrollToBottom();
+        }
+    }
+
+    private void refreshEmptyText() {
+        if((CaptureService.getHttpLog() != null) || CaptureService.isServiceActive())
+            mEmptyText.setText(mAdapter.hasFilter() ? R.string.no_matches_found : R.string.no_requests);
+        else
+            mEmptyText.setText(R.string.capture_not_running_status);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        mHandler = new Handler(Looper.getMainLooper());
+        mFabDown = view.findViewById(R.id.fabDown);
+        mRecyclerView = view.findViewById(R.id.connections_view);
+        EmptyRecyclerView.MyLinearLayoutManager layoutMan = new EmptyRecyclerView.MyLinearLayoutManager(requireContext());
+        mRecyclerView.setLayoutManager(layoutMan);
+        mApps = new AppsResolver(requireContext());
+
+        mEmptyText = view.findViewById(R.id.no_connections);
+        mAdapter = new HttpLogAdapter(requireContext(), mApps);
+        mRecyclerView.setAdapter(mAdapter);
+
+        DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(mRecyclerView.getContext(),
+                layoutMan.getOrientation());
+        mRecyclerView.addItemDecoration(dividerItemDecoration);
+
+        mAdapter.setClickListener(v -> {
+            int pos = mRecyclerView.getChildLayoutPosition(v);
+            HttpLog.HttpRequest item = mAdapter.getItem(pos);
+
+            if(item != null) {
+                Intent intent = new Intent(requireContext(), HttpDetailsActivity.class);
+                intent.putExtra(HttpDetailsActivity.HTTP_REQ_POS_KEY, item.getPosition());
+                startActivity(intent);
+            }
+        });
+
+        autoScroll = true;
+        showFabDown(false);
+        mFabDown.setOnClickListener(v -> scrollToBottom());
+
+        mRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
+                recheckScroll();
+            }
+        });
+
+        if(savedInstanceState != null) {
+            String search = savedInstanceState.getString("search");
+
+            if((search != null) && !search.isEmpty())
+                mQueryToApply = search;
+        }
+
+        CaptureService.observeStatus(this, serviceStatus -> {
+            if(serviceStatus == CaptureService.ServiceStatus.STARTED) {
+                unregisterHttpListener();
+                registerHttpListener();
+
+                autoScroll = true;
+                showFabDown(false);
+                mEmptyText.setText(R.string.no_requests);
+                mApps.clear();
+            }
+        });
+    }
+
+    @Override
+    public void onCreateMenu(@NonNull Menu menu, MenuInflater menuInflater) {
+        menuInflater.inflate(R.menu.http_log_menu, menu);
+
+        mMenuItemSearch = menu.findItem(R.id.search);
+
+        mSearchView = (SearchView) mMenuItemSearch.getActionView();
+        mSearchView.setOnQueryTextListener(this);
+
+        if((mQueryToApply != null) && (!mQueryToApply.isEmpty())) {
+            String query = mQueryToApply;
+            mQueryToApply = null;
+            setQuery(query);
+        }
+    }
+
+    @Override
+    public boolean onMenuItemSelected(@NonNull MenuItem item) {
+        return false;
+    }
+
+    private void setQuery(String query) {
+        Utils.setSearchQuery(mSearchView, mMenuItemSearch, query);
+    }
+
+    @Override
+    public boolean onQueryTextSubmit(String query) { return true; }
+
+    @Override
+    public boolean onQueryTextChange(String newText) {
+        mAdapter.setSearch(newText);
+        recheckScroll();
+        refreshEmptyText();
+        return true;
+    }
+
+    // NOTE: dispatched from activity, returns true if handled
+    public boolean onBackPressed() {
+        return Utils.backHandleSearchview(mSearchView);
+    }
+
+    @Override
+    public void onHttpRequestAdded(int pos) {
+        Utils.runOnUi(() -> {
+            if (mAdapter != null) {
+                mAdapter.onHttpRequestAdded(pos);
+
+                recheckScroll();
+                if (autoScroll)
+                    scrollToBottom();
+            }
+        }, mHandler);
+    }
+
+    @Override
+    public void onHttpRequestUpdated(int pos) {
+        Utils.runOnUi(() -> {
+            if (mAdapter != null)
+                mAdapter.onHttpRequestUpdated(pos);
+        }, mHandler);
+    }
+
+    @Override
+    public void onHttpRequestsClear() {
+        Utils.runOnUi(() -> {
+            if (mAdapter != null)
+                mAdapter.onHttpRequestsClear();
+        }, mHandler);
+    }
+
+    private void recheckScroll() {
+        final EmptyRecyclerView.MyLinearLayoutManager layoutMan = (EmptyRecyclerView.MyLinearLayoutManager) mRecyclerView.getLayoutManager();
+        assert layoutMan != null;
+        int first_visibile_pos = layoutMan.findFirstCompletelyVisibleItemPosition();
+        int last_visible_pos = layoutMan.findLastCompletelyVisibleItemPosition();
+        int last_pos = mAdapter.getItemCount() - 1;
+        boolean reached_bottom = (last_visible_pos >= last_pos);
+        boolean is_scrolling = (first_visibile_pos != 0) || (!reached_bottom);
+
+        if(is_scrolling) {
+            if(reached_bottom) {
+                autoScroll = true;
+                showFabDown(false);
+            } else {
+                autoScroll = false;
+                showFabDown(true);
+            }
+        } else
+            showFabDown(false);
+    }
+
+    private void showFabDown(boolean visible) {
+        // compared to setVisibility, .show/.hide provide animations and also properly clear the AnchorId
+        if(visible)
+            mFabDown.show();
+        else
+            mFabDown.hide();
+    }
+
+    private void scrollToBottom() {
+        int last_pos = mAdapter.getItemCount() - 1;
+        mRecyclerView.scrollToPosition(last_pos);
+
+        showFabDown(false);
+    }
+}

--- a/app/src/main/java/com/emanuelef/remote_capture/fragments/HttpPayloadFragment.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/fragments/HttpPayloadFragment.java
@@ -1,0 +1,207 @@
+/*
+ * This file is part of PCAPdroid.
+ *
+ * PCAPdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PCAPdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PCAPdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2020-24 - Emanuele Faranda
+ */
+
+package com.emanuelef.remote_capture.fragments;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.view.MenuProvider;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
+import androidx.preference.PreferenceManager;
+
+import com.emanuelef.remote_capture.CaptureService;
+import com.emanuelef.remote_capture.HttpLog;
+import com.emanuelef.remote_capture.Log;
+import com.emanuelef.remote_capture.R;
+import com.emanuelef.remote_capture.Utils;
+import com.emanuelef.remote_capture.activities.PayloadExportActivity;
+import com.emanuelef.remote_capture.adapters.PayloadAdapter;
+import com.emanuelef.remote_capture.model.Prefs;
+import com.emanuelef.remote_capture.views.EmptyRecyclerView;
+
+public class HttpPayloadFragment extends Fragment implements MenuProvider {
+    private static final String TAG = "ConnectionPayload";
+    private PayloadExportActivity mActivity;
+    private HttpLog.HttpRequest mHttpReq;
+    private PayloadAdapter mAdapter;
+    private EmptyRecyclerView mRecyclerView;
+    private Menu mMenu;
+    private boolean mJustCreated;
+    private boolean mShowAsPrintable;
+
+    public static HttpPayloadFragment newInstance(int req_pos, boolean show_reply) {
+        HttpPayloadFragment fragment = new HttpPayloadFragment();
+        Bundle args = new Bundle();
+        args.putSerializable("show_reply", show_reply);
+        args.putInt("req_pos", req_pos);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+
+        mActivity = (PayloadExportActivity) context;
+
+        if (mAdapter != null)
+            mAdapter.setExportPayloadHandler(mActivity);
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mActivity = null;
+
+        if (mAdapter != null)
+            mAdapter.setExportPayloadHandler(null);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater,
+                             ViewGroup container, Bundle savedInstanceState) {
+        requireActivity().addMenuProvider(this, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
+        return inflater.inflate(R.layout.connection_payload, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        Bundle args = getArguments();
+        assert args != null;
+
+        HttpLog httpLog = CaptureService.getHttpLog();
+        if (httpLog == null) {
+            mActivity.finish();
+            return;
+        }
+
+        mHttpReq = httpLog.getRequest(args.getInt("req_pos"));
+        if(mHttpReq == null) {
+            Utils.showToast(requireContext(), R.string.item_not_found);
+            mActivity.finish();
+            return;
+        }
+
+        mRecyclerView = view.findViewById(R.id.payload);
+        EmptyRecyclerView.MyLinearLayoutManager layoutMan = new EmptyRecyclerView.MyLinearLayoutManager(requireContext());
+        mRecyclerView.setLayoutManager(layoutMan);
+
+        boolean show_reply = args.getBoolean("show_reply");
+        mShowAsPrintable = true;
+        mAdapter = new PayloadAdapter(requireContext(), mHttpReq, show_reply);
+        mAdapter.setExportPayloadHandler(mActivity);
+        mJustCreated = true;
+
+        // only set adapter after acknowledged (see setMenuVisibility below)
+        if(payloadNoticeAcknowledged(PreferenceManager.getDefaultSharedPreferences(requireContext())))
+            mRecyclerView.setAdapter(mAdapter);
+    }
+
+    @Override
+    public void setMenuVisibility(boolean menuVisible) {
+        super.setMenuVisibility(menuVisible);
+
+        Context context = getContext();
+        if(context == null)
+            return;
+
+        Log.d(TAG, "setMenuVisibility : " + menuVisible);
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+        if(menuVisible && !payloadNoticeAcknowledged(prefs)) {
+            AlertDialog dialog = new AlertDialog.Builder(context)
+                    .setTitle(R.string.warning)
+                    .setMessage(R.string.payload_scams_notice)
+                    .setOnCancelListener((d) -> requireActivity().finish())
+                    .setNegativeButton(R.string.cancel_action, (d, b) -> requireActivity().finish())
+                    .setPositiveButton(R.string.show_data_action, (d, whichButton) -> {
+                        // show the data
+                        mRecyclerView.setAdapter(mAdapter);
+
+                        prefs.edit().putBoolean(Prefs.PREF_PAYLOAD_NOTICE_ACK, true).apply();
+                    }).show();
+
+            dialog.setCanceledOnTouchOutside(false);
+        }
+    }
+
+    private boolean payloadNoticeAcknowledged(SharedPreferences prefs) {
+        return prefs.getBoolean(Prefs.PREF_PAYLOAD_NOTICE_ACK, false);
+    }
+
+    @Override
+    public void onCreateMenu(@NonNull Menu menu, MenuInflater menuInflater) {
+        menuInflater.inflate(R.menu.connection_payload, menu);
+        mMenu = menu;
+        if(mJustCreated) {
+            mShowAsPrintable = true;
+            mAdapter.setDisplayAsPrintableText(true);
+            mJustCreated = false;
+        }
+        refreshDisplayMode();
+    }
+
+    @Override
+    public boolean onMenuItemSelected(@NonNull MenuItem item) {
+        int id = item.getItemId();
+
+        if(id == R.id.printable_text) {
+            mShowAsPrintable = true;
+            mAdapter.setDisplayAsPrintableText(true);
+            refreshDisplayMode();
+            return true;
+        } else if(id == R.id.hexdump) {
+            mShowAsPrintable = false;
+            mAdapter.setDisplayAsPrintableText(false);
+            refreshDisplayMode();
+            return true;
+        }
+
+        return false;
+    }
+
+    private void refreshDisplayMode() {
+        if(mMenu == null)
+            return;
+
+        MenuItem printableText = mMenu.findItem(R.id.printable_text);
+        MenuItem hexdump = mMenu.findItem(R.id.hexdump);
+
+        // important: the checked item must first be unchecked
+        if(mShowAsPrintable) {
+            hexdump.setChecked(false);
+            printableText.setChecked(true);
+        } else {
+            printableText.setChecked(false);
+            hexdump.setChecked(true);
+        }
+    }
+}

--- a/app/src/main/java/com/emanuelef/remote_capture/model/ConnectionDescriptor.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/model/ConnectionDescriptor.java
@@ -27,12 +27,14 @@ import androidx.annotation.Nullable;
 import com.emanuelef.remote_capture.AppsResolver;
 import com.emanuelef.remote_capture.CaptureService;
 import com.emanuelef.remote_capture.HTTPReassembly;
+import com.emanuelef.remote_capture.HttpLog;
 import com.emanuelef.remote_capture.R;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.concurrent.atomic.AtomicReference;
 
 /* Holds the information about a single connection.
@@ -43,7 +45,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * thread. However this does not create concurrency problems as the update only increments counters
  * or sets a previously null field to a non-null value.
  */
-public class ConnectionDescriptor {
+public class ConnectionDescriptor implements HTTPReassembly.ReassemblyListener {
     // sync with zdtun_conn_status_t
     public static final int CONN_STATUS_NEW = 0,
         CONN_STATUS_CONNECTING = 1,
@@ -125,6 +127,11 @@ public class ConnectionDescriptor {
     /* Internal */
     public boolean alerted;
     public boolean block_accounted;
+    private HTTPReassembly mHttpReqReassembly;
+    private HTTPReassembly mHttpReplyReassembly;
+    private int mFirstReqChunkPos = -1;
+    private int mFirstReplyChunkPos = -1;
+    private LinkedList<HttpLog.HttpRequest> mPendingRequests;
 
     public ConnectionDescriptor(int _incr_id, int _ipver, int _ipproto, String _src_ip, String _dst_ip,
                                 int _src_port, int _dst_port, int _local_port, int _uid, int _ifidx,
@@ -183,15 +190,48 @@ public class ConnectionDescriptor {
             // Payload for decryptable connections should be received via the MitmReceiver
             assert(decryption_ignored || isNotDecryptable());
 
-            // Some pending updates with payload may still be received after low memory has been
-            // triggered and payload disabled
-            if(!CaptureService.isLowMemory()) {
-                synchronized (this) {
+            synchronized (this) {
+                if (HTTPReassembly.TODO_ENABLED && (update.payload_chunks != null)) {
+                    int chunk_pos = payload_chunks.size();
+
+                    for (PayloadChunk chunk: update.payload_chunks) {
+                        if (chunk.type == PayloadChunk.ChunkType.HTTP)
+                            logHttpChunk(chunk, chunk_pos);
+
+                        chunk_pos++;
+                    }
+                }
+
+                // Some pending updates with payload may still be received after low memory has been
+                // triggered and payload disabled
+                if(!CaptureService.isLowMemory()) {
                     if(update.payload_chunks != null)
                         payload_chunks.addAll(update.payload_chunks);
                     payload_truncated = update.payload_truncated;
                 }
             }
+        }
+    }
+
+    private void logHttpChunk(PayloadChunk chunk, int chunk_pos) {
+        assert (chunk.type == PayloadChunk.ChunkType.HTTP);
+
+        if (mHttpReqReassembly == null) {
+            // use a lightweight reassembly, without dumping the payload
+            mHttpReqReassembly = new HTTPReassembly(true, this, false);
+            mHttpReplyReassembly = new HTTPReassembly(true, this, false);
+            mPendingRequests = new LinkedList<>();
+        }
+
+        // will call onChunkReassembled
+        if (chunk.is_sent) {
+            if (mFirstReqChunkPos == -1)
+                mFirstReqChunkPos = chunk_pos;
+            mHttpReqReassembly.handleChunk(chunk);
+        } else {
+            if (mFirstReplyChunkPos == -1)
+                mFirstReplyChunkPos = chunk_pos;
+            mHttpReplyReassembly.handleChunk(chunk);
         }
     }
 
@@ -320,6 +360,9 @@ public class ConnectionDescriptor {
     }
 
     public synchronized void addPayloadChunkMitm(PayloadChunk chunk) {
+        if (HTTPReassembly.TODO_ENABLED && (chunk.type == PayloadChunk.ChunkType.HTTP))
+            logHttpChunk(chunk, payload_chunks.size());
+
         payload_chunks.add(chunk);
         payload_length += chunk.payload.length;
     }
@@ -339,18 +382,21 @@ public class ConnectionDescriptor {
     public boolean hasHttpRequest() { return hasHttp(true); }
     public boolean hasHttpResponse() { return hasHttp(false); }
 
-    private synchronized String getHttp(boolean is_sent) {
-        if(getNumPayloadChunks() == 0)
-            return "";
+    private synchronized PayloadChunk getHttpChunks(boolean is_sent, int firstChunkPos) {
+        if((getNumPayloadChunks() == 0) || (firstChunkPos < 0))
+            return null;
 
         // Need to wrap the String to set it from the lambda
-        final AtomicReference<String> rv = new AtomicReference<>();
+        final AtomicReference<PayloadChunk> rv = new AtomicReference<>();
 
-        HTTPReassembly reassembly = new HTTPReassembly(CaptureService.getCurPayloadMode() == Prefs.PayloadMode.FULL, chunk ->
-                rv.set(new String(chunk.payload, StandardCharsets.UTF_8)));
+        HTTPReassembly reassembly = new HTTPReassembly(
+                CaptureService.getCurPayloadMode() == Prefs.PayloadMode.FULL,
+                rv::set);
 
         // Possibly reassemble/decode the request
-        for(PayloadChunk chunk: payload_chunks) {
+        for (int i = firstChunkPos; i < payload_chunks.size(); i++) {
+            PayloadChunk chunk = payload_chunks.get(i);
+
             if(chunk.is_sent == is_sent)
                 reassembly.handleChunk(chunk);
 
@@ -361,8 +407,58 @@ public class ConnectionDescriptor {
 
         return rv.get();
     }
-    public String getHttpRequest() { return getHttp(true); }
-    public String getHttpResponse() { return getHttp(false); }
+
+    private String getHttpAsString(boolean is_sent) {
+        PayloadChunk reassembled = getHttpChunks(is_sent, 0);
+        if (reassembled == null)
+            return "";
+
+        return new String(reassembled.payload, StandardCharsets.UTF_8);
+    }
+
+    public String getHttpRequest() { return getHttpAsString(true); }
+    public String getHttpResponse() { return getHttpAsString(false); }
+
+    public PayloadChunk getHttpRequestChunk(int firstChunkPos) { return getHttpChunks(true, firstChunkPos); }
+    public PayloadChunk getHttpResponseChunk(int firstChunkPos) { return getHttpChunks(false, firstChunkPos); }
+
+    @Override
+    public void onChunkReassembled(PayloadChunk chunk) {
+        if (chunk.type != PayloadChunk.ChunkType.HTTP)
+            return;
+
+        HttpLog httplog = CaptureService.getHttpLog();
+        if (httplog == null)
+            return;
+
+        if (chunk.is_sent) {
+            HttpLog.HttpRequest request = new HttpLog.HttpRequest(this, mFirstReqChunkPos);
+            request.host = !chunk.httpHost.isEmpty() ? chunk.httpHost : info;
+            request.method = chunk.httpMethod;
+            request.path = chunk.httpPath;
+            request.query = chunk.httpQuery;
+            request.bodyLength = chunk.httpBodyLength;
+            request.timestamp = chunk.timestamp;
+            httplog.addHttpRequest(request);
+
+            mPendingRequests.add(request);
+            mFirstReqChunkPos = -1;
+        } else if (mPendingRequests.size() > 0) {
+            // find the first un-replied request
+            HttpLog.HttpRequest request = mPendingRequests.remove(0);
+
+            HttpLog.HttpReply reply = new HttpLog.HttpReply(request, mFirstReplyChunkPos);
+            reply.responseCode = chunk.httpResponseCode;
+            reply.responseStatus = chunk.httpResponseStatus;
+            reply.contentType = chunk.httpContentType;
+            reply.bodyLength = chunk.httpBodyLength;
+            request.timestamp = chunk.timestamp;
+            request.reply = reply;
+            httplog.addHttpReply(reply);
+
+            mFirstReplyChunkPos = -1;
+        }
+    }
 
     public boolean hasSeenStart() {
         if((ipproto != 6 /* TCP */) || !CaptureService.isCapturingAsRoot())

--- a/app/src/main/java/com/emanuelef/remote_capture/model/PayloadChunk.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/model/PayloadChunk.java
@@ -27,8 +27,16 @@ public class PayloadChunk implements Serializable {
     public boolean is_sent;
     public long timestamp;
     public ChunkType type;
-    public String contentType;
-    public String path;
+
+    // HTTP
+    public int httpResponseCode = 0;
+    public String httpResponseStatus = "";
+    public String httpMethod = "";
+    public String httpHost = "";
+    public String httpPath = "";
+    public String httpQuery = "";
+    public String httpContentType = "";
+    public int httpBodyLength = 0;
 
     // Serializable need in ConnectionPayload fragment
     public enum ChunkType implements Serializable {
@@ -45,6 +53,9 @@ public class PayloadChunk implements Serializable {
     }
 
     public PayloadChunk subchunk(int start, int size) {
+        if (payload == null)
+            return this;
+
         byte[] subarr = new byte[size];
         System.arraycopy(payload, start, subarr, 0, size);
         return new PayloadChunk(subarr, type, is_sent, timestamp);

--- a/app/src/main/res/drawable/bars_staggered_solid.xml
+++ b/app/src/main/res/drawable/bars_staggered_solid.xml
@@ -1,0 +1,10 @@
+<!--
+    Resource generated based on Font Awesome 6 Free icons set:
+    https://fontawesome.com/
+-->
+<vector android:height="24dp" android:viewportHeight="512"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="512" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFFFFFFF"
+        android:pathData="M27.79,93.86C27.79,77.34 40.42,64 56.05,64H395.14c15.63,0 28.26,13.34 28.26,29.86 0,16.52 -12.63,29.86 -28.26,29.86H56.05c-15.63,0 -28.26,-13.34 -28.26,-29.86zM84.31,243.16c0,-16.52 12.63,-29.86 28.26,-29.86h339.09c15.63,0 28.26,13.34 28.26,29.86 0,16.52 -12.63,29.86 -28.26,29.86H112.57c-15.63,0 -28.26,-13.34 -28.26,-29.86zM423.4,392.46c0,16.52 -12.63,29.86 -28.26,29.86H56.05c-15.63,0 -28.26,-13.34 -28.26,-29.86 0,-16.52 12.63,-29.86 28.26,-29.86H395.14c15.63,0 28.26,13.34 28.26,29.86z" android:strokeWidth="0.907734"/>
+</vector>

--- a/app/src/main/res/layout/http_req_item.xml
+++ b/app/src/main/res/layout/http_req_item.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:layout_height="80dp"
+    android:background="?attr/selectableItemBackground"
+    android:orientation="horizontal"
+    android:paddingHorizontal="4dp"
+    android:paddingTop="3dp"
+    android:paddingBottom="3dp">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:adjustViewBounds="false"
+        android:gravity="center"
+        android:layout_width="40dp"
+        android:layout_height="match_parent"
+        android:layout_margin="2dp"
+        tools:src="@drawable/ic_apps"
+        tools:tint="?attr/colorAccent" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="0dp"
+        android:orientation="vertical"
+        android:paddingHorizontal="4dp"
+        android:layout_marginStart="5dp"
+        android:layout_weight="1"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:id="@+id/app_name_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintHorizontal_bias="0"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/app_name"
+                android:textStyle="bold"
+                android:textSize="14sp"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:layout_width="0dp"
+                android:layout_weight="3"
+                android:layout_marginEnd="10dp"
+                android:layout_height="wrap_content"
+                tools:text="Android" />
+
+            <TextView
+                android:id="@+id/content_type"
+                android:textSize="12sp"
+                android:layout_width="0dp"
+                android:layout_weight="2"
+                android:layout_height="wrap_content"
+                android:textAlignment="textEnd"
+                android:textColor="@color/in_progress"
+                app:layout_constraintTop_toTopOf="@id/app_name_layout"
+                app:layout_constraintBottom_toBottomOf="@id/app_name_layout"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:ellipsize="start"
+                android:singleLine="true"
+                tools:text="application/x-www-form-urlencoded" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/proto_and_host"
+            android:textSize="13sp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/app_name_layout"
+            android:ellipsize="middle"
+            android:singleLine="true"
+            tools:text="http://example.org" />
+
+        <TextView
+            android:id="@+id/method_and_path"
+            android:textSize="13sp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintTop_toBottomOf="@id/proto_and_host"
+            app:layout_constraintEnd_toStartOf="@id/req_time"
+            app:layout_constraintStart_toStartOf="parent"
+            android:singleLine="true"
+            android:ellipsize="middle"
+            tools:text="GET /images/24x24/some_image.png" />
+
+        <TextView
+            android:id="@+id/req_time"
+            android:textSize="12sp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/app_name_layout"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="17:15:00"/>
+
+        <TextView
+            android:id="@+id/http_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/payload_size"
+            app:layout_constraintTop_toBottomOf="@id/method_and_path"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:layout_marginTop="4dp"
+            tools:text="304 Not Modified"
+            android:textSize="12sp" />
+
+        <TextView
+            android:id="@+id/payload_size"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="105.4 MB"
+            android:textSize="12sp"
+            android:gravity="end"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/app/src/main/res/menu/http_log_menu.xml
+++ b/app/src/main/res/menu/http_log_menu.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <!-- NOTE: "always|collapseActionView" must be set to prevent the search button from
+         disappearing and to avoid hiding the other elements. -->
+    <item
+        android:id="@+id/search"
+        android:title="@string/search"
+        android:icon="@drawable/ic_search"
+        android:orderInCategory="15"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:showAsAction="always|collapseActionView"
+        tools:ignore="AlwaysShowAction" />
+</menu>

--- a/app/src/main/res/menu/nav_items.xml
+++ b/app/src/main/res/menu/nav_items.xml
@@ -14,6 +14,10 @@
             android:title="@string/decryption_rules"
             android:icon="@drawable/ic_lock_open_alt" />
         <item
+            android:id="@+id/http_log"
+            android:title="@string/http_log"
+            android:icon="@drawable/bars_staggered_solid" />
+        <item
             android:id="@+id/firewall"
             android:title="@string/firewall"
             android:icon="@drawable/ic_shield" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -510,4 +510,8 @@
     <string name="vpn_reconnection">VPN reconnection</string>
     <string name="vpn_reconnection_aborted">VPN reconnection aborted</string>
     <string name="waiting_for_vpn_disconnect">Waiting for the active VPN to disconnect…</string>
+    <string name="http_log">HTTP log</string>
+    <string name="no_requests">No requests</string>
+    <string name="item_not_found">Could not find the specified item</string>
+    <string name="http_details">HTTP details</string>
 </resources>


### PR DESCRIPTION
The log shows individual HTTP requests, allowing to inspect the requests and replies body. Currently this relies on the full payload option to be enabled. The searchbox is not implemented

See #416